### PR TITLE
Add data loader to load Iris dataset into Pandas DataFrame

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,2 @@
+IRIS_DB_PATH=tests/resources/mock_iris.sqlite
+IRIS_TABLE_NAME=Iris

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: download lint test run format format-check typecheck test-coverage jupyter env
+.PHONY: download lint test run format format-check typecheck test-coverage jupyter env preflight
 
 download:
 	$(shell scripts/download_data.sh)
@@ -27,3 +27,5 @@ test:
 
 test-coverage:
 	.venv/bin/pytest --cov=src --cov-report=xml
+
+preflight: lint format typecheck

--- a/README.md
+++ b/README.md
@@ -76,10 +76,16 @@ make test
 
 Linting, Code Formatting, and Type checking:
 
-```
+```bash
 make lint
 make format
 make typecheck
+```
+
+Alternative to run linter, formatter and type checking with a single command:
+
+```bash
+make preflight
 ```
 
 ## Testing and Code Coverage

--- a/src/config.py
+++ b/src/config.py
@@ -2,14 +2,14 @@ import os
 from pathlib import Path
 from dotenv import load_dotenv
 
-# Load variables from .env into environment
-env_file = ".env" if Path(".env").exists() else ".env.ci"
+# Load .env if it exists, else .env.ci
+env_file = Path(".env") if Path(".env").exists() else Path(".env.ci")
 load_dotenv(dotenv_path=env_file)
 
 # Base directory
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Env-based config
+# Environment-based config
 env_path = os.getenv("IRIS_DB_PATH")
 if env_path is None:
     raise RuntimeError("Environment variable IRIS_DB_PATH is not set.")

--- a/src/config.py
+++ b/src/config.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 # Load variables from .env into environment
-load_dotenv()
+env_file = ".env" if Path(".env").exists() else ".env.ci"
+load_dotenv(dotenv_path=env_file)
 
 # Base directory
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,11 @@ load_dotenv()
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Env-based config
-RAW_DATA_PATH = BASE_DIR / os.getenv("IRIS_DB_PATH")
+env_path = os.getenv("IRIS_DB_PATH")
+if env_path is None:
+    raise RuntimeError("Environment variable IRIS_DB_PATH is not set.")
+
+RAW_DATA_PATH = BASE_DIR / env_path
 IRIS_TABLE_NAME = os.getenv("IRIS_TABLE_NAME", "Iris")
 SEED = int(os.getenv("SEED", 42))
 

--- a/src/config.py
+++ b/src/config.py
@@ -6,18 +6,18 @@ from dotenv import load_dotenv
 env_file = Path(".env") if Path(".env").exists() else Path(".env.ci")
 load_dotenv(dotenv_path=env_file)
 
-# Base directory
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Environment-based config
-env_path = os.getenv("IRIS_DB_PATH")
-if env_path is None:
-    raise RuntimeError("Environment variable IRIS_DB_PATH is not set.")
 
-RAW_DATA_PATH = BASE_DIR / env_path
+def get_raw_data_path() -> Path:
+    env_path = os.getenv("IRIS_DB_PATH")
+    if env_path is None:
+        raise RuntimeError("Environment variable IRIS_DB_PATH is not set.")
+    return BASE_DIR / env_path
+
+
 IRIS_TABLE_NAME = os.getenv("IRIS_TABLE_NAME", "Iris")
 SEED = int(os.getenv("SEED", 42))
 
-# Derived paths
 DATA_DIR = BASE_DIR / "data"
 PROCESSED_DATA__DIR = DATA_DIR / "processed"

--- a/src/config.py
+++ b/src/config.py
@@ -6,10 +6,15 @@ from dotenv import load_dotenv
 env_file = Path(".env") if Path(".env").exists() else Path(".env.ci")
 load_dotenv(dotenv_path=env_file)
 
+# Base directory
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 def get_raw_data_path() -> Path:
+    """
+    Lazy-load IRIS_DB_PATH to compute its value at runtime.
+    This allows patched environment variables to take effect.
+    """
     env_path = os.getenv("IRIS_DB_PATH")
     if env_path is None:
         raise RuntimeError("Environment variable IRIS_DB_PATH is not set.")

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -4,7 +4,7 @@ import pandera as pa
 
 from pandera.typing.pandas import DataFrame
 
-from config import RAW_DATA_PATH, IRIS_TABLE_NAME
+from config import IRIS_TABLE_NAME, get_raw_data_path
 from schemas import IrisSchema
 
 
@@ -19,7 +19,7 @@ def get_iris_species_data() -> DataFrame[IrisSchema]:
          Returns a dataframe with the IrisSchema schema
     """
 
-    conn = sqlite3.connect(RAW_DATA_PATH)
+    conn = sqlite3.connect(get_raw_data_path())
     query = f"SELECT * FROM {IRIS_TABLE_NAME}"
     df = pd.read_sql(query, conn)
     conn.close()

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -1,0 +1,26 @@
+import sqlite3
+import pandas as pd
+import pandera as pa
+
+from pandera.typing.pandas import DataFrame
+
+from config import RAW_DATA_PATH, IRIS_TABLE_NAME
+from schemas import IrisSchema
+
+
+@pa.check_types
+def get_iris_species_data() -> DataFrame[IrisSchema]:
+    """
+    Load Iris dataset from sqlite database
+
+    Returns
+    -------
+    df : DataFrame[IrisSchema]
+         Returns a dataframe with the IrisSchema schema
+    """
+
+    conn = sqlite3.connect(RAW_DATA_PATH)
+    query = f"SELECT * FROM {IRIS_TABLE_NAME}"
+    df = pd.read_sql(query, conn)
+
+    return IrisSchema.validate(df)

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -22,5 +22,6 @@ def get_iris_species_data() -> DataFrame[IrisSchema]:
     conn = sqlite3.connect(RAW_DATA_PATH)
     query = f"SELECT * FROM {IRIS_TABLE_NAME}"
     df = pd.read_sql(query, conn)
+    conn.close()
 
     return IrisSchema.validate(df)

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -1,0 +1,15 @@
+from pandera import DataFrameModel, Field
+from pandera.typing.pandas import Series
+
+
+class IrisSchema(DataFrameModel):
+    """
+    DataFrame Schema for the Iris dataset
+    """
+
+    Id: Series[int] = Field(gt=0)
+    SepalLengthCm: Series[float] = Field(gt=0)
+    SepalWidthCm: Series[float] = Field(gt=0)
+    PetalLengthCm: Series[float] = Field(gt=0)
+    PetalWidthCm: Series[float] = Field(gt=0)
+    Species: Series[str]

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -24,7 +24,7 @@ def mock_iris_db(tmp_path: Path) -> Path:
         }
     )
 
-    df.to_sql("iris", conn, index=False, if_exists="replace")
+    df.to_sql("Iris", conn, index=False, if_exists="replace")
     conn.close()
 
     return db_path

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,0 +1,9 @@
+from data.load_data import get_iris_species_data
+from pandera.typing.pandas import DataFrame
+
+from schemas import IrisSchema
+
+
+def test_loading_data() -> None:
+    df: DataFrame[IrisSchema] = get_iris_species_data()
+    assert df.shape[0] < 0

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,9 +1,46 @@
+import pytest
+import pandas as pd
+import sqlite3
+
 from data.load_data import get_iris_species_data
 from pandera.typing.pandas import DataFrame
 
 from schemas import IrisSchema
 
+@pytest.fixture
+def mock_iris_db(tmp_path) -> str:
+    """Create in-memory SQLite DB and populate with dummy Iris data"""
 
-def test_loading_data() -> None:
-    df: DataFrame[IrisSchema] = get_iris_species_data()
-    assert df.shape[0] < 0
+    db_path = tmp_path / "mock_iris.sqlite"
+    conn = sqlite3.connect(db_path)
+
+    df = pd.DataFrame({
+        "Id": [1,2],
+        "SepalLengthCm": [5.1, 4.9],
+        "SepalWidthCm": [3.5, 3.0],
+        "PetalLengthCm": [1.4, 1.4],
+        "PetalWidthCm": [0.2, 0.2],
+        "Species": ["Iris-setosa", "Iris-setosa"],
+    })
+
+    df.to_sql("iris", conn, index=False, if_exists="replace")
+    conn.close()
+
+    return db_path
+
+
+@pytest.mark.usefixtures("mock_iris_db")
+def test_loading_data(monkeypatch, mock_iris_db) -> None:
+    # Patch the RAW_DATA_PATH config path
+    monkeypatch.setenv("IRIS_DB_PATH", str(mock_iris_db))
+
+    df = get_iris_species_data()
+
+    assert not df.empty
+    assert df.shape[0] > 0
+    assert df.shape[1] > 0
+    assert list(df.columns) == [
+        "Id", "SepalLengthCm", "SepalWidthCm", "PetalLengthCm", "PetalWidthCm", "Species"
+    ]
+
+

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -35,6 +35,10 @@ def test_loading_data(monkeypatch: pytest.MonkeyPatch, mock_iris_db: Path) -> No
     # Patch the RAW_DATA_PATH config path
     monkeypatch.setenv("IRIS_DB_PATH", str(mock_iris_db))
 
+    import config
+
+    monkeypatch.setattr(config, "RAW_DATA_PATH", mock_iris_db)
+
     df = get_iris_species_data()
 
     assert not df.empty

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -35,10 +35,6 @@ def test_loading_data(monkeypatch: pytest.MonkeyPatch, mock_iris_db: Path) -> No
     # Patch the RAW_DATA_PATH config path
     monkeypatch.setenv("IRIS_DB_PATH", str(mock_iris_db))
 
-    import config
-
-    monkeypatch.setattr(config, "RAW_DATA_PATH", mock_iris_db)
-
     df = get_iris_species_data()
 
     assert not df.empty

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -2,26 +2,27 @@ import pytest
 import pandas as pd
 import sqlite3
 
+from pathlib import Path
 from data.load_data import get_iris_species_data
-from pandera.typing.pandas import DataFrame
 
-from schemas import IrisSchema
 
 @pytest.fixture
-def mock_iris_db(tmp_path) -> str:
+def mock_iris_db(tmp_path: Path) -> Path:
     """Create in-memory SQLite DB and populate with dummy Iris data"""
 
     db_path = tmp_path / "mock_iris.sqlite"
     conn = sqlite3.connect(db_path)
 
-    df = pd.DataFrame({
-        "Id": [1,2],
-        "SepalLengthCm": [5.1, 4.9],
-        "SepalWidthCm": [3.5, 3.0],
-        "PetalLengthCm": [1.4, 1.4],
-        "PetalWidthCm": [0.2, 0.2],
-        "Species": ["Iris-setosa", "Iris-setosa"],
-    })
+    df = pd.DataFrame(
+        {
+            "Id": [1, 2],
+            "SepalLengthCm": [5.1, 4.9],
+            "SepalWidthCm": [3.5, 3.0],
+            "PetalLengthCm": [1.4, 1.4],
+            "PetalWidthCm": [0.2, 0.2],
+            "Species": ["Iris-setosa", "Iris-setosa"],
+        }
+    )
 
     df.to_sql("iris", conn, index=False, if_exists="replace")
     conn.close()
@@ -30,7 +31,7 @@ def mock_iris_db(tmp_path) -> str:
 
 
 @pytest.mark.usefixtures("mock_iris_db")
-def test_loading_data(monkeypatch, mock_iris_db) -> None:
+def test_loading_data(monkeypatch: pytest.MonkeyPatch, mock_iris_db: Path) -> None:
     # Patch the RAW_DATA_PATH config path
     monkeypatch.setenv("IRIS_DB_PATH", str(mock_iris_db))
 
@@ -40,7 +41,10 @@ def test_loading_data(monkeypatch, mock_iris_db) -> None:
     assert df.shape[0] > 0
     assert df.shape[1] > 0
     assert list(df.columns) == [
-        "Id", "SepalLengthCm", "SepalWidthCm", "PetalLengthCm", "PetalWidthCm", "Species"
+        "Id",
+        "SepalLengthCm",
+        "SepalWidthCm",
+        "PetalLengthCm",
+        "PetalWidthCm",
+        "Species",
     ]
-
-


### PR DESCRIPTION
# Pull Request

## Summary 

In this PR, we add a data loader module to load the Iris dataset from the sqlite database (see [data loading script](https://github.com/StefanNieuwenhuis/iris_species_classifier/blob/9e42a2586b0110a9c55b15ee2fdb4c284064933f/scripts/download_data.sh)) into a Pandas dataframe.

## Proposed Changes

- Add loader module
- Add unit tests

## Testing Instructions

- Check out this branch `git pull && git checkout stefannhs/add/data-loader`
- run `make env`
- run `make test` or `make test-coverage` to generate a code coverage report

## Checklist

 - [x] Code follows [PEP8](https://peps.python.org/pep-0008/)
 - [x] I updated documentation (README/code comments/configs)
 - [x] I’ve added tests where necessary

